### PR TITLE
Fix/#120

### DIFF
--- a/src/components/gallery/index.tsx
+++ b/src/components/gallery/index.tsx
@@ -91,7 +91,7 @@ const GalleryListing = ({ category }: State): JSX.Element => {
   useEffect(() => {
     setTimeout(() => {
       fetchData(category);
-    }, 1000);
+    }, 500);
   }, []);
 
   const itemsPerPage = 8;

--- a/src/components/gallery/index.tsx
+++ b/src/components/gallery/index.tsx
@@ -100,7 +100,11 @@ const GalleryListing = ({ category }: State): JSX.Element => {
   const currentItems = list.slice(indexOfFirstItem, indexOfLastItem);
 
   const handlePageChange = (PageNumber: number) => {
+    setLoading(true);
     setCurrentPage(PageNumber);
+    setTimeout(() => {
+      setLoading(false);
+    }, 500);
   };
 
   if (loading) {

--- a/src/components/wiki/Intro/Intro.tsx
+++ b/src/components/wiki/Intro/Intro.tsx
@@ -33,7 +33,7 @@ const Intro = () => {
   useEffect(() => {
     setTimeout(() => {
       fetchData();
-    }, 1000);
+    }, 500);
   }, []);
 
   if (loading) {

--- a/src/components/wiki/Notice/Notice.tsx
+++ b/src/components/wiki/Notice/Notice.tsx
@@ -33,7 +33,7 @@ const Notice = () => {
   useEffect(() => {
     setTimeout(() => {
       fetchData();
-    }, 1000);
+    }, 500);
   }, []);
 
   if (loading) {


### PR DESCRIPTION
## 관련 이슈

Close #120 

## Description

갤러리 페이지에서 페이지네이션 사용하여 페이지 넘겼을 때 이미지 로딩되는 동안 스켈레톤 UI 0.5초 보여주도록 추가했습니다.

## ETC

기존에 추가되어있던 스켈레톤 UI 모두 **1초 ➡️ 0.5초**로 바꾸었습니다.
로딩 시간에는 큰 차이 없어서 좀 더 빨리 로드되는게 좋은것같더라구요!
